### PR TITLE
Master fusionv2.3.5 patch

### DIFF
--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -7,7 +7,8 @@ report_section_order:
     order: -1001
   "nf-core-rnaseq-summary":
     order: -1002
-
+max_table_rows: 3000
+log_filesize_limit: 2000000000
 export_plots: true
 disable_version_detection: true
 

--- a/modules/local/multiqc/main.nf
+++ b/modules/local/multiqc/main.nf
@@ -43,7 +43,7 @@ process MULTIQC {
     path ('rseqc/read_distribution/*')
     path ('rseqc/read_duplication/*')
     path ('rseqc/tin/*')
-    //path ('umitools/*')
+    path ('umitools/*')
 
     output:
     path "*multiqc_report.html", emit: report

--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -911,8 +911,8 @@ workflow RNASEQ {
             ch_junctionsaturation_multiqc.collect{it[1]}.ifEmpty([]),
             ch_readdistribution_multiqc.collect{it[1]}.ifEmpty([]),
             ch_readduplication_multiqc.collect{it[1]}.ifEmpty([]),
-            ch_tin_multiqc.collect{it[1]}.ifEmpty([])
-            //ch_umidedup_multiqc.collect{it[1]}.ifEmpty([])
+            ch_tin_multiqc.collect{it[1]}.ifEmpty([]),
+            ch_umidedup_multiqc.collect{it[1]}.ifEmpty([])
         )
         multiqc_report = MULTIQC.out.report.toList()
     }


### PR DESCRIPTION
- add umi tools dedup to multiqc report
- add back 'cp' instead of 'mv' for SortMeRNA
