### PR TITLE
feat: add read sub-sampling with seqtk sample

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -343,6 +343,32 @@ if (params.remove_ribo_rna) {
 }
 
 //
+// Read sub-sampling options
+//
+
+if (!params.skip_subsample) {
+    process {
+        withName: 'COUNT_READS' {
+            publishDir = [
+                path: { "${params.outdir}/subsample" },
+                mode: params.publish_dir_mode,
+                enabled: false
+            ]
+        }
+
+        withName: 'SEQTK_SAMPLE' {
+            ext.args   = '-s100'
+            publishDir = [
+                path: { "${params.outdir}/subsample" },
+                mode: params.publish_dir_mode,
+                pattern: "*.fastq.gz",
+                enabled: false
+            ]
+        }
+    }
+}
+
+//
 // General alignment options
 //
 

--- a/modules.json
+++ b/modules.json
@@ -8,169 +8,235 @@
                     "bbmap/bbsplit": {
                         "branch": "master",
                         "git_sha": "de3e6fc949dcffb8d3508c015f435ace5773ff08",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cat/fastq": {
                         "branch": "master",
                         "git_sha": "5c460c5a4736974abde2843294f35307ee2b0e5e",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "bba7e362e4afead70653f84d8700588ea28d0f9e",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/custom/dumpsoftwareversions/custom-dumpsoftwareversions.diff"
                     },
                     "custom/getchromsizes": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "fastp": {
                         "branch": "master",
                         "git_sha": "d497a4868ace3302016ea8ed4b395072d5e833cd",
-                        "installed_by": ["fastq_fastqc_umitools_fastp", "modules"],
+                        "installed_by": [
+                            "fastq_fastqc_umitools_fastp",
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/fastp/fastp.diff"
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "102cc9b709a6da9f7cee2373563ab1464fca9c0a",
-                        "installed_by": ["fastq_fastqc_umitools_trimgalore", "fastq_fastqc_umitools_fastp"],
+                        "installed_by": [
+                            "fastq_fastqc_umitools_trimgalore",
+                            "fastq_fastqc_umitools_fastp"
+                        ],
                         "patch": "modules/nf-core/fastqc/fastqc.diff"
                     },
                     "fq/subsample": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["modules", "fastq_subsample_fq_salmon"]
+                        "installed_by": [
+                            "modules",
+                            "fastq_subsample_fq_salmon"
+                        ]
                     },
                     "gffread": {
                         "branch": "master",
                         "git_sha": "4ab13872435962dadc239979554d13709e20bf29",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "e06548bfa36ee31869b81041879dd6b3a83b1d57",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "hisat2/align": {
                         "branch": "master",
                         "git_sha": "a1881f6374506f9e031b7af814768cdb44a6a7d3",
-                        "installed_by": ["fastq_align_hisat2"]
+                        "installed_by": [
+                            "fastq_align_hisat2"
+                        ]
                     },
                     "hisat2/build": {
                         "branch": "master",
                         "git_sha": "f2f48836bf5c59434966a6c3b2211b29363f31ab",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "hisat2/extractsplicesites": {
                         "branch": "master",
                         "git_sha": "735e1e04e7e01751d2d6e97055bbdb6f70683cc1",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "kallisto/index": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "kallisto/quant": {
                         "branch": "master",
                         "git_sha": "bdc2a97ced7adc423acfa390742db83cab98c1ad",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "picard/markduplicates": {
                         "branch": "master",
                         "git_sha": "2ee934606f1fdf7fc1cb05d6e8abc13bec8ab448",
-                        "installed_by": ["bam_markduplicates_picard"]
+                        "installed_by": [
+                            "bam_markduplicates_picard"
+                        ]
                     },
                     "preseq/lcextrap": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "qualimap/rnaseq": {
                         "branch": "master",
                         "git_sha": "4657d98bc9f565e067c4d924126ce107056f5e2f",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/qualimap/rnaseq/qualimap-rnaseq.diff"
                     },
                     "rsem/calculateexpression": {
                         "branch": "master",
                         "git_sha": "603ecbd9f45300c9788f197d2a15a005685b4220",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "rsem/preparereference": {
                         "branch": "master",
                         "git_sha": "603ecbd9f45300c9788f197d2a15a005685b4220",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "rseqc/bamstat": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/bamstat/rseqc-bamstat.diff"
                     },
                     "rseqc/inferexperiment": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/inferexperiment/rseqc-inferexperiment.diff"
                     },
                     "rseqc/innerdistance": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/innerdistance/rseqc-innerdistance.diff"
                     },
                     "rseqc/junctionannotation": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/junctionannotation/rseqc-junctionannotation.diff"
                     },
                     "rseqc/junctionsaturation": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/junctionsaturation/rseqc-junctionsaturation.diff"
                     },
                     "rseqc/readdistribution": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/readdistribution/rseqc-readdistribution.diff"
                     },
                     "rseqc/readduplication": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/readduplication/rseqc-readduplication.diff"
                     },
                     "rseqc/tin": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/tin/rseqc-tin.diff"
                     },
                     "salmon/index": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["fastq_subsample_fq_salmon"]
+                        "installed_by": [
+                            "fastq_subsample_fq_salmon"
+                        ]
                     },
                     "salmon/quant": {
                         "branch": "master",
                         "git_sha": "c5b528d0a51c31621b485ab3bcc008f483619ea6",
-                        "installed_by": ["modules", "fastq_subsample_fq_salmon"]
+                        "installed_by": [
+                            "modules",
+                            "fastq_subsample_fq_salmon"
+                        ]
                     },
                     "samtools/flagstat": {
                         "branch": "master",
                         "git_sha": "570ec5bcfe19c49e16c9ca35a7a116563af6cc1c",
-                        "installed_by": ["bam_stats_samtools"]
+                        "installed_by": [
+                            "bam_stats_samtools"
+                        ]
                     },
                     "samtools/idxstats": {
                         "branch": "master",
                         "git_sha": "e662ab16e0c11f1e62983e21de9871f59371a639",
-                        "installed_by": ["bam_stats_samtools"]
+                        "installed_by": [
+                            "bam_stats_samtools"
+                        ]
                     },
                     "samtools/index": {
                         "branch": "master",
@@ -184,69 +250,103 @@
                     "samtools/sort": {
                         "branch": "master",
                         "git_sha": "a0f7be95788366c1923171e358da7d049eb440f9",
-                        "installed_by": ["bam_sort_stats_samtools"]
+                        "installed_by": [
+                            "bam_sort_stats_samtools"
+                        ]
                     },
                     "samtools/stats": {
                         "branch": "master",
                         "git_sha": "735e1e04e7e01751d2d6e97055bbdb6f70683cc1",
-                        "installed_by": ["bam_stats_samtools"]
+                        "installed_by": [
+                            "bam_stats_samtools"
+                        ]
                     },
                     "sortmerna": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "star/align": {
                         "branch": "master",
                         "git_sha": "cc08a888069f67cab8120259bddab8032d4c0fe3",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "star/genomegenerate": {
                         "branch": "master",
                         "git_sha": "cc08a888069f67cab8120259bddab8032d4c0fe3",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "stringtie/stringtie": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "subread/featurecounts": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "trimgalore": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["fastq_fastqc_umitools_trimgalore"]
+                        "installed_by": [
+                            "fastq_fastqc_umitools_trimgalore"
+                        ]
                     },
                     "ucsc/bedclip": {
                         "branch": "master",
                         "git_sha": "240937a2a9c30298110753292be041188891f2cb",
-                        "installed_by": ["bedgraph_bedclip_bedgraphtobigwig"]
+                        "installed_by": [
+                            "bedgraph_bedclip_bedgraphtobigwig"
+                        ]
                     },
                     "ucsc/bedgraphtobigwig": {
                         "branch": "master",
                         "git_sha": "66290981ab6038ea86177ade40b9449bc790b0ce",
-                        "installed_by": ["bedgraph_bedclip_bedgraphtobigwig"]
+                        "installed_by": [
+                            "bedgraph_bedclip_bedgraphtobigwig"
+                        ]
                     },
                     "umitools/dedup": {
                         "branch": "master",
                         "git_sha": "7297204bf49273300a3dbfa4b7a4027c8683f1bd",
-                        "installed_by": ["bam_dedup_stats_samtools_umitools"],
+                        "installed_by": [
+                            "bam_dedup_stats_samtools_umitools"
+                        ],
                         "patch": "modules/nf-core/umitools/dedup/umitools-dedup.diff"
                     },
                     "umitools/extract": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["fastq_fastqc_umitools_fastp", "fastq_fastqc_umitools_trimgalore"],
+                        "installed_by": [
+                            "fastq_fastqc_umitools_fastp",
+                            "fastq_fastqc_umitools_trimgalore"
+                        ],
                         "patch": "modules/nf-core/umitools/extract/umitools-extract.diff"
                     },
                     "untar": {
                         "branch": "master",
                         "git_sha": "d0b4fc03af52a1cc8c6fb4493b921b57352b1dd8",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
+                    "seqtk/sample": {
+                        "branch": "master",
+                        "git_sha": "manual_install",
+                        "installed_by": [
+                            "modules"
+                        ]
                     }
                 }
             },
@@ -255,22 +355,30 @@
                     "bam_dedup_stats_samtools_umitools": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "bam_markduplicates_picard": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "bam_rseqc": {
                         "branch": "master",
                         "git_sha": "a9784afdd5dcda23b84e64db75dc591065d64653",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "bam_sort_stats_samtools": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["fastq_align_hisat2"]
+                        "installed_by": [
+                            "fastq_align_hisat2"
+                        ]
                     },
                     "bam_stats_samtools": {
                         "branch": "master",
@@ -284,27 +392,37 @@
                     "bedgraph_bedclip_bedgraphtobigwig": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "fastq_align_hisat2": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "fastq_fastqc_umitools_fastp": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "fastq_fastqc_umitools_trimgalore": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "fastq_subsample_fq_salmon": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     }
                 }
             }

--- a/modules/local/count_reads/main.nf
+++ b/modules/local/count_reads/main.nf
@@ -1,0 +1,28 @@
+process COUNT_READS {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "conda-forge::coreutils=9.5"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
+        'biocontainers/biocontainers:v1.2.0_cv2' }"
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path(reads), env(NUM_READS), emit: reads_with_count
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    """
+    # Count total number of reads across all FASTQ files for this sample
+    # For paired-end, count only R1 to get the number of read pairs
+    # For single-end, count all reads
+    FIRST_FILE=\$(echo $reads | tr ' ' '\\n' | head -1)
+    NUM_LINES=\$(zcat \$FIRST_FILE | wc -l)
+    NUM_READS=\$((NUM_LINES / 4))
+    """
+}

--- a/modules/nf-core/seqtk/sample/environment.yml
+++ b/modules/nf-core/seqtk/sample/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::seqtk=1.4

--- a/modules/nf-core/seqtk/sample/main.nf
+++ b/modules/nf-core/seqtk/sample/main.nf
@@ -1,0 +1,58 @@
+process SEQTK_SAMPLE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/seqtk:1.4--he4a0461_1' :
+        'biocontainers/seqtk:1.4--he4a0461_1' }"
+
+    input:
+    tuple val(meta), path(reads), val(sample_size)
+
+    output:
+    tuple val(meta), path("*.fastq.gz"), emit: reads
+    path  "versions.yml"               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if (!(args ==~ /.*\ -s\ ?[0-9]+.*/)) {
+        args += " -s100"
+    }
+    if ( !sample_size ) {
+        error "SEQTK/SAMPLE must have a sample_size value included"
+    }
+    """
+    printf "%s\\n" $reads | while read f;
+    do
+        seqtk \\
+            sample \\
+            $args \\
+            \$f \\
+            $sample_size \\
+            | gzip --no-name > ${prefix}_\$(basename \$f)
+    done
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqtk: \$(seqtk 2>&1 | sed -n 's/^Version: //p')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    echo "" | gzip > ${prefix}.fastq.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqtk: \$(seqtk 2>&1 | sed -n 's/^Version: //p')
+    END_VERSIONS
+    """
+
+}

--- a/modules/nf-core/seqtk/sample/meta.yml
+++ b/modules/nf-core/seqtk/sample/meta.yml
@@ -1,0 +1,70 @@
+name: seqtk_sample
+description: Subsample reads from FASTQ files
+keywords:
+  - sample
+  - fastx
+  - reads
+tools:
+  - seqtk:
+      description: Seqtk is a fast and lightweight tool for processing sequences
+        in the FASTA or FASTQ format. Seqtk sample command subsamples sequences.
+      homepage: https://github.com/lh3/seqtk
+      documentation: https://docs.csc.fi/apps/seqtk/
+      tool_dev_url: https://github.com/lh3/seqtk
+      licence: ["MIT"]
+      identifier: biotools:seqtk
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: List of input FastQ files
+        pattern: "*.{fastq.gz}"
+        ontologies: []
+    - sample_size:
+        type: float
+        description: Fraction (<1.0) or number (>=1) of reads to sample.
+output:
+  reads:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fastq.gz":
+          type: file
+          description: Subsampled FastQ files
+          pattern: "*.{fastq.gz}"
+          ontologies: []
+  versions_seqtk:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - seqtk:
+          type: string
+          description: The name of the tool
+      - "seqtk 2>&1 | sed -n 's/^Version: //p'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - seqtk:
+          type: string
+          description: The name of the tool
+      - "seqtk 2>&1 | sed -n 's/^Version: //p'":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@kaurravneet4123"
+  - "@sidorov-si"
+  - "@adamrtalbot"
+maintainers:
+  - "@kaurravneet4123"
+  - "@sidorov-si"
+  - "@adamrtalbot"

--- a/nextflow.config
+++ b/nextflow.config
@@ -56,6 +56,10 @@ params {
     save_non_ribo_reads        = false
     ribo_database_manifest     = "${projectDir}/assets/rrna-db-defaults.txt"
 
+    // Read sub-sampling
+    skip_subsample             = false
+    subsample_reads_threshold  = 60000000  // 60 Million reads
+
     // Alignment
     aligner                    = 'star_salmon'
     pseudo_aligner             = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,10 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": [
+                "input",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -224,7 +227,10 @@
                     "default": "trimgalore",
                     "description": "Specifies the trimming tool to use - available options are 'trimgalore' and 'fastp'.",
                     "fa_icon": "fas fa-cut",
-                    "enum": ["trimgalore", "fastp"]
+                    "enum": [
+                        "trimgalore",
+                        "fastp"
+                    ]
                 },
                 "extra_trimgalore_args": {
                     "type": "string",
@@ -282,6 +288,19 @@
                     "fa_icon": "fas fa-database",
                     "description": "Text file containing paths to fasta files (one per line) that will be used to create the database for SortMeRNA.",
                     "help_text": "By default, [rRNA databases](https://github.com/biocore/sortmerna/tree/master/data/rRNA_databases) defined in the SortMeRNA GitHub repo are used. You can see an example in the pipeline Github repository in `assets/rrna-default-dbs.txt`.\nPlease note that commercial/non-academic entities require [`licensing for SILVA`](https://www.arb-silva.de/silva-license-information) for these default databases."
+                },
+                "skip_subsample": {
+                    "type": "boolean",
+                    "description": "Skip read sub-sampling step.",
+                    "fa_icon": "fas fa-fast-forward",
+                    "default": false
+                },
+                "subsample_reads_threshold": {
+                    "type": "integer",
+                    "description": "Maximum number of reads per sample. Samples exceeding this threshold will be subsampled down to this number using seqtk sample.",
+                    "fa_icon": "fas fa-hashtag",
+                    "default": 60000000,
+                    "help_text": "Set to 0 to disable subsampling. Only the first read file (R1 for paired-end) is counted to determine the number of reads."
                 }
             },
             "fa_icon": "fas fa-trash-alt"
@@ -330,7 +349,13 @@
                     "default": "directional",
                     "fa_icon": "far fa-object-ungroup",
                     "description": "Method to use to determine read groups by subsuming those with similar UMIs. All methods start by identifying the reads with the same mapping position, but treat similar yet nonidentical UMIs differently.",
-                    "enum": ["unique", "percentile", "cluster", "adjacency", "directional"]
+                    "enum": [
+                        "unique",
+                        "percentile",
+                        "cluster",
+                        "adjacency",
+                        "directional"
+                    ]
                 },
                 "umitools_dedup_stats": {
                     "type": "boolean",
@@ -352,13 +377,20 @@
                     "default": "star_salmon",
                     "description": "Specifies the alignment algorithm to use - available options are 'star_salmon', 'star_rsem' and 'hisat2'.",
                     "fa_icon": "fas fa-map-signs",
-                    "enum": ["star_salmon", "star_rsem", "hisat2"]
+                    "enum": [
+                        "star_salmon",
+                        "star_rsem",
+                        "hisat2"
+                    ]
                 },
                 "pseudo_aligner": {
                     "type": "string",
                     "description": "Specifies the pseudo aligner to use - available options are 'salmon'. Runs in addition to '--aligner'.",
                     "fa_icon": "fas fa-hamburger",
-                    "enum": ["salmon", "kallisto"]
+                    "enum": [
+                        "salmon",
+                        "kallisto"
+                    ]
                 },
                 "pseudo_aligner_kmer_size": {
                     "type": "integer",
@@ -624,6 +656,12 @@
                     "type": "boolean",
                     "fa_icon": "fas fa-fast-forward",
                     "description": "Skip all QC steps except for MultiQC."
+                },
+                "skip_subsample": {
+                    "type": "boolean",
+                    "description": "Skip read sub-sampling step.",
+                    "fa_icon": "fas fa-fast-forward",
+                    "default": false
                 }
             }
         },
@@ -742,7 +780,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -112,6 +112,7 @@ include { DUPRADAR                           } from '../modules/local/dupradar'
 include { MULTIQC                            } from '../modules/local/multiqc'
 include { MULTIQC_CUSTOM_BIOTYPE             } from '../modules/local/multiqc_custom_biotype'
 include { UMITOOLS_PREPAREFORRSEM as UMITOOLS_PREPAREFORSALMON } from '../modules/local/umitools_prepareforrsem'
+include { COUNT_READS                        } from '../modules/local/count_reads'
 
 //
 // SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
@@ -140,6 +141,7 @@ include { SORTMERNA                   } from '../modules/nf-core/sortmerna'
 include { STRINGTIE_STRINGTIE         } from '../modules/nf-core/stringtie/stringtie'
 include { SUBREAD_FEATURECOUNTS       } from '../modules/nf-core/subread/featurecounts'
 include { CUSTOM_DUMPSOFTWAREVERSIONS } from '../modules/nf-core/custom/dumpsoftwareversions'
+include { SEQTK_SAMPLE                } from '../modules/nf-core/seqtk/sample'
 
 //
 // SUBWORKFLOW: Consisting entirely of nf-core/modules
@@ -347,7 +349,32 @@ workflow RNASEQ {
         ch_sortmerna_multiqc = SORTMERNA.out.log
         ch_versions = ch_versions.mix(SORTMERNA.out.versions.first())
     }
-    
+
+    //
+    // MODULE: Sub-sample reads if total read count exceeds threshold
+    //
+    if (!params.skip_subsample) {
+        COUNT_READS ( ch_filtered_reads )
+
+        COUNT_READS.out.reads_with_count
+            .branch {
+                meta, reads, num_reads ->
+                    subsample: num_reads.toLong() > params.subsample_reads_threshold
+                        return [ meta, reads, params.subsample_reads_threshold ]
+                    passthrough: true
+                        return [ meta, reads ]
+            }
+            .set { ch_reads_to_subsample }
+
+        SEQTK_SAMPLE ( ch_reads_to_subsample.subsample )
+        ch_versions = ch_versions.mix(SEQTK_SAMPLE.out.versions.first())
+
+        // Mix subsampled reads with those that did not need subsampling
+        SEQTK_SAMPLE.out.reads
+            .mix(ch_reads_to_subsample.passthrough)
+            .set { ch_filtered_reads }
+    }
+
     //
     // SUBWORKFLOW: Sub-sample FastQ files and pseudoalign with Salmon to auto-infer strandedness
     //


### PR DESCRIPTION
## Summary

Adds automatic read sub-sampling for samples exceeding a configurable threshold (default: 60 million reads). This prevents excessively deep samples from dominating compute time and memory during alignment and quantification.

## Changes

### New modules
| Module | Type | Purpose |
|--------|------|---------|
| `COUNT_READS` | local | Counts reads in the first FASTQ file (R1 for paired-end) to determine sample depth |
| `SEQTK_SAMPLE` | nf-core | Sub-samples FASTQ files down to the target read count using `seqtk sample` |

### New parameters
| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `skip_subsample` | boolean | `false` | Skip the sub-sampling step entirely |
| `subsample_reads_threshold` | integer | `60000000` | Maximum reads per sample; samples above this are subsampled down |

### Workflow integration
- The sub-sampling step runs **after** rRNA removal / adapter filtering but **before** strandedness inference and alignment
- Samples below the threshold pass through unchanged (zero overhead)
- Only R1 is counted for paired-end data to determine read pairs
- Uses `seqtk sample` with a fixed random seed (`-s100`) for reproducibility

### Files changed
- `workflows/rnaseq.nf` — workflow wiring for COUNT_READS → branch → SEQTK_SAMPLE → mix
- `modules/local/count_reads/main.nf` — new local module
- `modules/nf-core/seqtk/sample/` — new nf-core module (main.nf, meta.yml, environment.yml)
- `conf/modules.config` — process configs for both modules (publishing disabled by default)
- `nextflow.config` — new params with defaults
- `nextflow_schema.json` — schema entries in read_filtering_options and process_skipping_options
- `modules.json` — registered seqtk/sample module