### PR TITLE
feat: add seqtk/sample read sub-sampling step

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -306,7 +306,7 @@ if (!params.skip_subsample) {
             publishDir = [
                 path: { "${params.outdir}/seqtk" },
                 mode: params.publish_dir_mode,
-                pattern: '*.fastq.gz',
+                pattern: '*.f{ast,}q.gz',
                 enabled: false
             ]
         }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -297,6 +297,23 @@ if (params.with_umi && !params.skip_umi_extract) {
 }
 
 //
+// Read sub-sampling options
+//
+
+if (!params.skip_subsample) {
+    process {
+        withName: 'SEQTK_SAMPLE' {
+            publishDir = [
+                path: { "${params.outdir}/seqtk" },
+                mode: params.publish_dir_mode,
+                pattern: '*.fastq.gz',
+                enabled: false
+            ]
+        }
+    }
+}
+
+//
 // Contaminant removal options
 //
 

--- a/modules.json
+++ b/modules.json
@@ -8,169 +8,235 @@
                     "bbmap/bbsplit": {
                         "branch": "master",
                         "git_sha": "de3e6fc949dcffb8d3508c015f435ace5773ff08",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cat/fastq": {
                         "branch": "master",
                         "git_sha": "5c460c5a4736974abde2843294f35307ee2b0e5e",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "bba7e362e4afead70653f84d8700588ea28d0f9e",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/custom/dumpsoftwareversions/custom-dumpsoftwareversions.diff"
                     },
                     "custom/getchromsizes": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "fastp": {
                         "branch": "master",
                         "git_sha": "d497a4868ace3302016ea8ed4b395072d5e833cd",
-                        "installed_by": ["fastq_fastqc_umitools_fastp", "modules"],
+                        "installed_by": [
+                            "fastq_fastqc_umitools_fastp",
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/fastp/fastp.diff"
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "102cc9b709a6da9f7cee2373563ab1464fca9c0a",
-                        "installed_by": ["fastq_fastqc_umitools_trimgalore", "fastq_fastqc_umitools_fastp"],
+                        "installed_by": [
+                            "fastq_fastqc_umitools_trimgalore",
+                            "fastq_fastqc_umitools_fastp"
+                        ],
                         "patch": "modules/nf-core/fastqc/fastqc.diff"
                     },
                     "fq/subsample": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["modules", "fastq_subsample_fq_salmon"]
+                        "installed_by": [
+                            "modules",
+                            "fastq_subsample_fq_salmon"
+                        ]
                     },
                     "gffread": {
                         "branch": "master",
                         "git_sha": "4ab13872435962dadc239979554d13709e20bf29",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "e06548bfa36ee31869b81041879dd6b3a83b1d57",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "hisat2/align": {
                         "branch": "master",
                         "git_sha": "a1881f6374506f9e031b7af814768cdb44a6a7d3",
-                        "installed_by": ["fastq_align_hisat2"]
+                        "installed_by": [
+                            "fastq_align_hisat2"
+                        ]
                     },
                     "hisat2/build": {
                         "branch": "master",
                         "git_sha": "f2f48836bf5c59434966a6c3b2211b29363f31ab",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "hisat2/extractsplicesites": {
                         "branch": "master",
                         "git_sha": "735e1e04e7e01751d2d6e97055bbdb6f70683cc1",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "kallisto/index": {
                         "branch": "master",
                         "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "kallisto/quant": {
                         "branch": "master",
                         "git_sha": "bdc2a97ced7adc423acfa390742db83cab98c1ad",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "picard/markduplicates": {
                         "branch": "master",
                         "git_sha": "2ee934606f1fdf7fc1cb05d6e8abc13bec8ab448",
-                        "installed_by": ["bam_markduplicates_picard"]
+                        "installed_by": [
+                            "bam_markduplicates_picard"
+                        ]
                     },
                     "preseq/lcextrap": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "qualimap/rnaseq": {
                         "branch": "master",
                         "git_sha": "4657d98bc9f565e067c4d924126ce107056f5e2f",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/qualimap/rnaseq/qualimap-rnaseq.diff"
                     },
                     "rsem/calculateexpression": {
                         "branch": "master",
                         "git_sha": "603ecbd9f45300c9788f197d2a15a005685b4220",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "rsem/preparereference": {
                         "branch": "master",
                         "git_sha": "603ecbd9f45300c9788f197d2a15a005685b4220",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "rseqc/bamstat": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/bamstat/rseqc-bamstat.diff"
                     },
                     "rseqc/inferexperiment": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/inferexperiment/rseqc-inferexperiment.diff"
                     },
                     "rseqc/innerdistance": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/innerdistance/rseqc-innerdistance.diff"
                     },
                     "rseqc/junctionannotation": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/junctionannotation/rseqc-junctionannotation.diff"
                     },
                     "rseqc/junctionsaturation": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/junctionsaturation/rseqc-junctionsaturation.diff"
                     },
                     "rseqc/readdistribution": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/readdistribution/rseqc-readdistribution.diff"
                     },
                     "rseqc/readduplication": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/readduplication/rseqc-readduplication.diff"
                     },
                     "rseqc/tin": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["bam_rseqc"],
+                        "installed_by": [
+                            "bam_rseqc"
+                        ],
                         "patch": "modules/nf-core/rseqc/tin/rseqc-tin.diff"
                     },
                     "salmon/index": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["fastq_subsample_fq_salmon"]
+                        "installed_by": [
+                            "fastq_subsample_fq_salmon"
+                        ]
                     },
                     "salmon/quant": {
                         "branch": "master",
                         "git_sha": "c5b528d0a51c31621b485ab3bcc008f483619ea6",
-                        "installed_by": ["modules", "fastq_subsample_fq_salmon"]
+                        "installed_by": [
+                            "modules",
+                            "fastq_subsample_fq_salmon"
+                        ]
                     },
                     "samtools/flagstat": {
                         "branch": "master",
                         "git_sha": "570ec5bcfe19c49e16c9ca35a7a116563af6cc1c",
-                        "installed_by": ["bam_stats_samtools"]
+                        "installed_by": [
+                            "bam_stats_samtools"
+                        ]
                     },
                     "samtools/idxstats": {
                         "branch": "master",
                         "git_sha": "e662ab16e0c11f1e62983e21de9871f59371a639",
-                        "installed_by": ["bam_stats_samtools"]
+                        "installed_by": [
+                            "bam_stats_samtools"
+                        ]
                     },
                     "samtools/index": {
                         "branch": "master",
@@ -184,69 +250,103 @@
                     "samtools/sort": {
                         "branch": "master",
                         "git_sha": "a0f7be95788366c1923171e358da7d049eb440f9",
-                        "installed_by": ["bam_sort_stats_samtools"]
+                        "installed_by": [
+                            "bam_sort_stats_samtools"
+                        ]
                     },
                     "samtools/stats": {
                         "branch": "master",
                         "git_sha": "735e1e04e7e01751d2d6e97055bbdb6f70683cc1",
-                        "installed_by": ["bam_stats_samtools"]
+                        "installed_by": [
+                            "bam_stats_samtools"
+                        ]
                     },
                     "sortmerna": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "star/align": {
                         "branch": "master",
                         "git_sha": "cc08a888069f67cab8120259bddab8032d4c0fe3",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "star/genomegenerate": {
                         "branch": "master",
                         "git_sha": "cc08a888069f67cab8120259bddab8032d4c0fe3",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "stringtie/stringtie": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "subread/featurecounts": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "trimgalore": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["fastq_fastqc_umitools_trimgalore"]
+                        "installed_by": [
+                            "fastq_fastqc_umitools_trimgalore"
+                        ]
                     },
                     "ucsc/bedclip": {
                         "branch": "master",
                         "git_sha": "240937a2a9c30298110753292be041188891f2cb",
-                        "installed_by": ["bedgraph_bedclip_bedgraphtobigwig"]
+                        "installed_by": [
+                            "bedgraph_bedclip_bedgraphtobigwig"
+                        ]
                     },
                     "ucsc/bedgraphtobigwig": {
                         "branch": "master",
                         "git_sha": "66290981ab6038ea86177ade40b9449bc790b0ce",
-                        "installed_by": ["bedgraph_bedclip_bedgraphtobigwig"]
+                        "installed_by": [
+                            "bedgraph_bedclip_bedgraphtobigwig"
+                        ]
                     },
                     "umitools/dedup": {
                         "branch": "master",
                         "git_sha": "7297204bf49273300a3dbfa4b7a4027c8683f1bd",
-                        "installed_by": ["bam_dedup_stats_samtools_umitools"],
+                        "installed_by": [
+                            "bam_dedup_stats_samtools_umitools"
+                        ],
                         "patch": "modules/nf-core/umitools/dedup/umitools-dedup.diff"
                     },
                     "umitools/extract": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["fastq_fastqc_umitools_fastp", "fastq_fastqc_umitools_trimgalore"],
+                        "installed_by": [
+                            "fastq_fastqc_umitools_fastp",
+                            "fastq_fastqc_umitools_trimgalore"
+                        ],
                         "patch": "modules/nf-core/umitools/extract/umitools-extract.diff"
                     },
                     "untar": {
                         "branch": "master",
                         "git_sha": "d0b4fc03af52a1cc8c6fb4493b921b57352b1dd8",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
+                    "seqtk/sample": {
+                        "branch": "master",
+                        "git_sha": "b613e70e2f3dae1e5e91e7a3ad1bd7ccdab8d3da",
+                        "installed_by": [
+                            "modules"
+                        ]
                     }
                 }
             },
@@ -255,22 +355,30 @@
                     "bam_dedup_stats_samtools_umitools": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "bam_markduplicates_picard": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "bam_rseqc": {
                         "branch": "master",
                         "git_sha": "a9784afdd5dcda23b84e64db75dc591065d64653",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "bam_sort_stats_samtools": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["fastq_align_hisat2"]
+                        "installed_by": [
+                            "fastq_align_hisat2"
+                        ]
                     },
                     "bam_stats_samtools": {
                         "branch": "master",
@@ -284,27 +392,37 @@
                     "bedgraph_bedclip_bedgraphtobigwig": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "fastq_align_hisat2": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "fastq_fastqc_umitools_fastp": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "fastq_fastqc_umitools_trimgalore": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "fastq_subsample_fq_salmon": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     }
                 }
             }

--- a/modules/nf-core/seqtk/sample/environment.yml
+++ b/modules/nf-core/seqtk/sample/environment.yml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::seqtk=1.4

--- a/modules/nf-core/seqtk/sample/main.nf
+++ b/modules/nf-core/seqtk/sample/main.nf
@@ -1,0 +1,58 @@
+process SEQTK_SAMPLE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/seqtk:1.4--he4a0461_1' :
+        'biocontainers/seqtk:1.4--he4a0461_1' }"
+
+    input:
+    tuple val(meta), path(reads), val(sample_size)
+
+    output:
+    tuple val(meta), path("*.fastq.gz"), emit: reads
+    path  "versions.yml"               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if (!(args ==~ /.*\ -s\ ?[0-9]+.*/)) {
+        args += " -s100"
+    }
+    if ( !sample_size ) {
+        error "SEQTK/SAMPLE must have a sample_size value included"
+    }
+    """
+    printf "%s\\n" $reads | while read f;
+    do
+        seqtk \\
+            sample \\
+            $args \\
+            \$f \\
+            $sample_size \\
+            | gzip --no-name > ${prefix}_\$(basename \$f)
+    done
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqtk: \$(seqtk 2>&1 | sed -n 's/^Version: //p')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    echo "" | gzip > ${prefix}.fastq.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqtk: \$(seqtk 2>&1 | sed -n 's/^Version: //p')
+    END_VERSIONS
+    """
+
+}

--- a/modules/nf-core/seqtk/sample/main.nf
+++ b/modules/nf-core/seqtk/sample/main.nf
@@ -11,7 +11,7 @@ process SEQTK_SAMPLE {
     tuple val(meta), path(reads), val(sample_size)
 
     output:
-    tuple val(meta), path("*.fastq.gz"), emit: reads
+    tuple val(meta), path("*.f{ast,}q.gz"), emit: reads
     path  "versions.yml"               , emit: versions
 
     when:

--- a/modules/nf-core/seqtk/sample/meta.yml
+++ b/modules/nf-core/seqtk/sample/meta.yml
@@ -1,0 +1,40 @@
+name: seqtk_sample
+description: Subsample reads from FASTQ files
+keywords:
+  - sample
+  - fastx
+  - reads
+tools:
+  - seqtk:
+      description: Toolkit for processing sequences in FASTA/Q formats
+      homepage: https://github.com/lh3/seqtk
+      documentation: https://docs.csc.fi/apps/seqtk/
+      tool_dev_url: https://github.com/lh3/seqtk
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: List of input FastQ files
+      pattern: "*.{fastq.gz}"
+  - sample_size:
+      type: float
+      description: Fraction (<1.0) or number (>=1) of reads to sample
+output:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: Subsampled FastQ files
+      pattern: "*.{fastq.gz}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@kaurravneet4123"
+  - "@sidorov-si"
+  - "@adamrtalbot"

--- a/nextflow.config
+++ b/nextflow.config
@@ -46,6 +46,10 @@ params {
     save_trimmed               = false
     skip_trimming              = false
 
+    // Read sub-sampling
+    skip_subsample             = true
+    subsample_reads_threshold  = 50000000
+
     // BBSplit genome filtering
     bbsplit_fasta_list         = null
     save_bbsplit_reads         = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,10 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": [
+                "input",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -224,7 +227,10 @@
                     "default": "trimgalore",
                     "description": "Specifies the trimming tool to use - available options are 'trimgalore' and 'fastp'.",
                     "fa_icon": "fas fa-cut",
-                    "enum": ["trimgalore", "fastp"]
+                    "enum": [
+                        "trimgalore",
+                        "fastp"
+                    ]
                 },
                 "extra_trimgalore_args": {
                     "type": "string",
@@ -241,6 +247,13 @@
                     "default": 10000,
                     "fa_icon": "fas fa-hand-paper",
                     "description": "Minimum number of trimmed reads below which samples are removed from further processing. Some downstream steps in the pipeline will fail if this threshold is too low."
+                },
+                "subsample_reads_threshold": {
+                    "type": "integer",
+                    "description": "Maximum number of reads per sample. Samples exceeding this threshold will be sub-sampled using seqtk sample.",
+                    "fa_icon": "fas fa-hand-paper",
+                    "default": 50000000,
+                    "help_text": "When skip_subsample is false, any sample with more reads than this value after trimming will be randomly sub-sampled down to this many reads. Set to 0 to disable threshold-based sub-sampling."
                 }
             }
         },
@@ -330,7 +343,13 @@
                     "default": "directional",
                     "fa_icon": "far fa-object-ungroup",
                     "description": "Method to use to determine read groups by subsuming those with similar UMIs. All methods start by identifying the reads with the same mapping position, but treat similar yet nonidentical UMIs differently.",
-                    "enum": ["unique", "percentile", "cluster", "adjacency", "directional"]
+                    "enum": [
+                        "unique",
+                        "percentile",
+                        "cluster",
+                        "adjacency",
+                        "directional"
+                    ]
                 },
                 "umitools_dedup_stats": {
                     "type": "boolean",
@@ -352,13 +371,20 @@
                     "default": "star_salmon",
                     "description": "Specifies the alignment algorithm to use - available options are 'star_salmon', 'star_rsem' and 'hisat2'.",
                     "fa_icon": "fas fa-map-signs",
-                    "enum": ["star_salmon", "star_rsem", "hisat2"]
+                    "enum": [
+                        "star_salmon",
+                        "star_rsem",
+                        "hisat2"
+                    ]
                 },
                 "pseudo_aligner": {
                     "type": "string",
                     "description": "Specifies the pseudo aligner to use - available options are 'salmon'. Runs in addition to '--aligner'.",
                     "fa_icon": "fas fa-hamburger",
-                    "enum": ["salmon", "kallisto"]
+                    "enum": [
+                        "salmon",
+                        "kallisto"
+                    ]
                 },
                 "pseudo_aligner_kmer_size": {
                     "type": "integer",
@@ -624,6 +650,12 @@
                     "type": "boolean",
                     "fa_icon": "fas fa-fast-forward",
                     "description": "Skip all QC steps except for MultiQC."
+                },
+                "skip_subsample": {
+                    "type": "boolean",
+                    "description": "Skip sub-sampling of reads with seqtk sample.",
+                    "fa_icon": "fas fa-fast-forward",
+                    "default": true
                 }
             }
         },
@@ -742,7 +774,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -140,6 +140,7 @@ include { SORTMERNA                   } from '../modules/nf-core/sortmerna'
 include { STRINGTIE_STRINGTIE         } from '../modules/nf-core/stringtie/stringtie'
 include { SUBREAD_FEATURECOUNTS       } from '../modules/nf-core/subread/featurecounts'
 include { CUSTOM_DUMPSOFTWAREVERSIONS } from '../modules/nf-core/custom/dumpsoftwareversions'
+include { SEQTK_SAMPLE                } from '../modules/nf-core/seqtk/sample'
 
 //
 // SUBWORKFLOW: Consisting entirely of nf-core/modules
@@ -313,6 +314,33 @@ workflow RNASEQ {
                 WorkflowRnaseq.multiqcTsvFromList(tsv_data, header)
         }
         .set { ch_fail_trimming_multiqc }
+
+    //
+    // MODULE: Sub-sample reads if total read count exceeds threshold
+    //
+    if (!params.skip_subsample) {
+        // Use the trim_read_count channel (emitted by both TrimGalore and fastp
+        // subworkflows) to decide which samples need sub-sampling.
+        // Join the read count back to the reads channel so we can branch.
+        ch_filtered_reads
+            .join(ch_trim_read_count)
+            .branch {
+                meta, reads, num_reads ->
+                    subsample: num_reads.toLong() > params.subsample_reads_threshold
+                        return [ meta, reads, params.subsample_reads_threshold ]
+                    passthrough: true
+                        return [ meta, reads ]
+            }
+            .set { ch_reads_to_subsample }
+
+        SEQTK_SAMPLE ( ch_reads_to_subsample.subsample )
+        ch_versions = ch_versions.mix(SEQTK_SAMPLE.out.versions.first())
+
+        // Mix subsampled reads with those that did not need subsampling
+        SEQTK_SAMPLE.out.reads
+            .mix(ch_reads_to_subsample.passthrough)
+            .set { ch_filtered_reads }
+    }
 
     //
     // MODULE: Remove genome contaminant reads

--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -322,12 +322,15 @@ workflow RNASEQ {
         // Use the trim_read_count channel (emitted by both TrimGalore and fastp
         // subworkflows) to decide which samples need sub-sampling.
         // Join the read count back to the reads channel so we can branch.
+        // IMPORTANT: Pass a fractional sample_size (threshold / read_count) so
+        // that seqtk uses streaming mode and does NOT load all reads into memory.
         ch_filtered_reads
             .join(ch_trim_read_count)
             .branch {
                 meta, reads, num_reads ->
                     subsample: num_reads.toLong() > params.subsample_reads_threshold
-                        return [ meta, reads, params.subsample_reads_threshold ]
+                        def fraction = params.subsample_reads_threshold / num_reads.toDouble()
+                        return [ meta, reads, fraction ]
                     passthrough: true
                         return [ meta, reads ]
             }


### PR DESCRIPTION
## Summary

Adds an optional read sub-sampling step using the **nf-core/seqtk/sample** module. When enabled, samples whose post-trimming read count exceeds a configurable threshold are randomly down-sampled before alignment.

## New Parameters

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `--skip_subsample` | boolean | `true` | Skip read sub-sampling step |
| `--subsample_reads_threshold` | integer | `50000000` | Maximum reads per sample; samples above this are down-sampled |

## How It Works

1. After trimming (TrimGalore/fastp) and before BBSplit/SortMeRNA, the workflow uses the existing `ch_trim_read_count` channel to check each sample's post-trimming read count
2. Samples exceeding `--subsample_reads_threshold` are routed to `SEQTK_SAMPLE` for random down-sampling to exactly that many reads
3. Samples below the threshold pass through untouched
4. Both streams are merged back into `ch_filtered_reads` for downstream processing

## Usage

```bash
nextflow run . \
    --input samplesheet.csv \
    --outdir results \
    --genome GRCh38 \
    --skip_subsample false \
    --subsample_reads_threshold 50000000
```

## Files Changed

- **`modules/nf-core/seqtk/sample/`** — New module (main.nf, meta.yml, environment.yml)
- **`workflows/rnaseq.nf`** — Wiring between trimming and contaminant removal
- **`nextflow.config`** — New params with safe defaults (disabled by default)
- **`conf/modules.config`** — Process config for SEQTK_SAMPLE
- **`nextflow_schema.json`** — Schema entries for Launchpad UI
- **`modules.json`** — Module registry entry

## Notes

- **Off by default** (`skip_subsample = true`) — no impact on existing runs
- Uses `seqtk sample` with seed `-s100` for reproducibility
- Container: `biocontainers/seqtk:1.4--he4a0461_1`